### PR TITLE
feat: Add list method to emails service

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.19.1';
+    public const VERSION = '0.20.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.20.0';
+    public const VERSION = '0.21.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Service/Email.php
+++ b/src/Service/Email.php
@@ -47,6 +47,8 @@ class Email extends Service
     /**
      * List all emails.
      *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
+     *
      * @see https://resend.com/docs/api-reference/emails/list-emails
      */
     public function list(array $options = []): \Resend\Collection

--- a/src/Service/Email.php
+++ b/src/Service/Email.php
@@ -23,7 +23,7 @@ class Email extends Service
     /**
      * Send an email with the given parameters.
      *
-     * @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
+     * @see https://resend.com/docs/api-reference/emails/send-email
      */
     public function create(array $parameters, array $options = []): \Resend\Email
     {
@@ -37,11 +37,25 @@ class Email extends Service
     /**
      * Send an email with the given parameters.
      *
-     * @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
+     * @see https://resend.com/docs/api-reference/emails/send-email
      */
     public function send(array $parameters, array $options = []): \Resend\Email
     {
         return $this->create($parameters, $options);
+    }
+
+    /**
+     * List all emails.
+     *
+     * @see https://resend.com/docs/api-reference/emails/list-emails
+     */
+    public function list(array $options = []): \Resend\Collection
+    {
+        $payload = Payload::list('emails', $options);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('emails', $result);
     }
 
     /**

--- a/src/ValueObjects/Transporter/Payload.php
+++ b/src/ValueObjects/Transporter/Payload.php
@@ -27,11 +27,25 @@ final class Payload
     /**
      * Create a new Transporter Payload instance.
      */
-    public static function list(string $resource): self
+    public static function list(string $resource, array $options = []): self
     {
         $contentType = ContentType::JSON;
         $method = Method::GET;
-        $uri = ResourceUri::list($resource);
+        $searchParams = [];
+
+        if (array_key_exists('limit', $options)) {
+            $searchParams['limit'] = $options['limit'];
+        }
+
+        if (array_key_exists('after', $options)) {
+            $searchParams['after'] = $options['after'];
+        }
+
+        if (array_key_exists('before', $options)) {
+            $searchParams['before'] = $options['before'];
+        }
+
+        $uri = ResourceUri::list(! empty($searchParams) ? $resource . '?' . http_build_query($searchParams) : $resource);
 
         return new self($contentType, $method, $uri);
     }

--- a/tests/Fixtures/Email.php
+++ b/tests/Fixtures/Email.php
@@ -10,6 +10,26 @@ function email(): array
     ];
 }
 
+function emails(): array
+{
+    return [
+        'data' => [
+            [
+                'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+                'from' => 'onboarding@resend.dev',
+                'to' => 'user@gmail.com',
+                'created_at' => '2022-07-25T00:28:32.493138+00:00',
+            ],
+            [
+                'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+                'from' => 'onboarding@resend.dev',
+                'to' => 'user@gmail.com',
+                'created_at' => '2022-07-25T00:28:32.493138+00:00',
+            ],
+        ],
+    ];
+}
+
 function batch(): array
 {
     return [

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -21,6 +21,9 @@ function mockClient(string $method, string $resource, array $parameters, array $
 
             $request = $payload->toRequest($baseUri, $headers);
 
+            $uri = (string) $request->getUri();
+            $pathWithQuery = str_replace('https://' . $request->getUri()->getHost(), '', $uri);
+
             if ($method === 'POST' || $method === 'PATCH' || $method === 'PUT') {
                 $expectedBody = ($parameters === [] || ! array_is_list($parameters))
                     ? json_encode((object) $parameters, JSON_THROW_ON_ERROR)
@@ -43,7 +46,7 @@ function mockClient(string $method, string $resource, array $parameters, array $
 
             return $request->getMethod() === $method
                 && $request->getHeader('User-Agent')[0] === 'resend-php/' . Resend::VERSION
-                && $request->getUri()->getPath() === "/{$resource}";
+                && $pathWithQuery === "/{$resource}";
         })->andReturn($response);
 
     return new Client($transporter);

--- a/tests/Service/Email.php
+++ b/tests/Service/Email.php
@@ -1,5 +1,6 @@
 <?php
 
+use Resend\Collection;
 use Resend\Email;
 
 it('can get an email resource', function () {
@@ -47,4 +48,40 @@ it('can cancel a scheduled email', function () {
 
     expect($result)->toBeInstanceOf(Email::class)
         ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
+});
+
+it('can get a list of email resources', function () {
+    $client = mockClient('GET', 'emails', [], [], emails());
+
+    $result = $client->emails->list();
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can get a list of email resources with a limit', function () {
+    $client = mockClient('GET', 'emails?limit=2', [], [], emails());
+
+    $result = $client->emails->list(['limit' => 2]);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can get a list of email resources before cursor', function () {
+    $client = mockClient('GET', 'emails?before=cursor123', [], [], emails());
+
+    $result = $client->emails->list(['before' => 'cursor123']);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can get a list of email resources after cursor', function () {
+    $client = mockClient('GET', 'emails?after=cursor123', [], [], emails());
+
+    $result = $client->emails->list(['after' => 'cursor123']);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
 });

--- a/tests/ValueObjects/Transporter/Payload.php
+++ b/tests/ValueObjects/Transporter/Payload.php
@@ -37,6 +37,24 @@ it('does not have a body when making a GET request', function () {
     expect($payload->toRequest($baseUri, $headers)->getBody()->getContents())->toBe('');
 });
 
+it('can create pagination requests', function () {
+    $payload = Payload::list('emails', ['limit' => 2, 'after' => 'cursor123', 'before' => 'cursor789']);
+
+    $baseUri = BaseUri::from('api.resend.com');
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+
+    expect((string) $payload->toRequest($baseUri, $headers)->getUri())->toBe('https://api.resend.com/emails?limit=2&after=cursor123&before=cursor789');
+});
+
+it('can create pagination requests with a single option', function () {
+    $payload = Payload::list('emails', ['limit' => 2]);
+
+    $baseUri = BaseUri::from('api.resend.com');
+    $headers = Headers::withAuthorization(ApiKey::from('foo'))->withContentType(ContentType::JSON);
+
+    expect((string) $payload->toRequest($baseUri, $headers)->getUri())->toBe('https://api.resend.com/emails?limit=2');
+});
+
 it('does not have a body when making a DELETE request', function () {
     $payload = Payload::delete('api-keys', 're_123456');
 


### PR DESCRIPTION
This PR adds a `list` method to the `emails` service, allowing you to get a list of paginated emails. You can pass in `limit`, `before` and/or `after` params to the `list` method to control the paginated results.