### PR TITLE
feat: add pagination support for all resources

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.21.0';
+    public const VERSION = '0.22.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Service/ApiKey.php
+++ b/src/Service/ApiKey.php
@@ -23,13 +23,14 @@ class ApiKey extends Service
     /**
      * List all API keys.
      *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
      * @return \Resend\Collection<\Resend\ApiKey>
      *
      * @see https://resend.com/docs/api-reference/api-keys/list-api-keys
      */
-    public function list(): \Resend\Collection
+    public function list(array $options = []): \Resend\Collection
     {
-        $payload = Payload::list('api-keys');
+        $payload = Payload::list('api-keys', $options);
 
         $result = $this->transporter->request($payload);
 

--- a/src/Service/Audience.php
+++ b/src/Service/Audience.php
@@ -37,13 +37,14 @@ class Audience extends Service
     /**
      * List all audiences.
      *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
      * @return \Resend\Collection<\Resend\Audience>
      *
      * @see https://resend.com/docs/api-reference/audiences/list-audiences
      */
-    public function list(): \Resend\Collection
+    public function list(array $options = []): \Resend\Collection
     {
-        $payload = Payload::list('audiences');
+        $payload = Payload::list('audiences', $options);
 
         $result = $this->transporter->request($payload);
 

--- a/src/Service/Broadcast.php
+++ b/src/Service/Broadcast.php
@@ -37,13 +37,14 @@ class Broadcast extends Service
     /**
      * List all domains.
      *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
      * @return \Resend\Collection<\Resend\Broadcast>
      *
      * @see https://resend.com/docs/api-reference/broadcasts/list-broadcasts
      */
-    public function list(): \Resend\Collection
+    public function list(array $options = []): \Resend\Collection
     {
-        $payload = Payload::list('broadcasts');
+        $payload = Payload::list('broadcasts', $options);
 
         $result = $this->transporter->request($payload);
 

--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -44,13 +44,14 @@ class Contact extends Service
     /**
      * List all contacts from an audience.
      *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
      * @return \Resend\Collection<\Resend\Contact>
      *
      * @see https://resend.com/docs/api-reference/contacts/list-contacts
      */
-    public function list(string $audienceId): \Resend\Collection
+    public function list(string $audienceId, array $options = []): \Resend\Collection
     {
-        $payload = Payload::list("audiences/$audienceId/contacts");
+        $payload = Payload::list("audiences/$audienceId/contacts", $options);
 
         $result = $this->transporter->request($payload);
 

--- a/src/Service/Domain.php
+++ b/src/Service/Domain.php
@@ -37,13 +37,14 @@ class Domain extends Service
     /**
      * List all domains.
      *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
      * @return \Resend\Collection<\Resend\Domain>
      *
      * @see https://resend.com/docs/api-reference/domains/list-domains
      */
-    public function list(): \Resend\Collection
+    public function list(array $options = []): \Resend\Collection
     {
-        $payload = Payload::list('domains');
+        $payload = Payload::list('domains', $options);
 
         $result = $this->transporter->request($payload);
 


### PR DESCRIPTION
This PR adds pagination support for all `list` methods on all resources.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add cursor-based pagination to all list methods across the SDK, so clients can page through large datasets efficiently. Also bumps SDK version to 0.22.0.

- New Features
  - ApiKey, Audience, Broadcast, Contact, and Domain list methods now accept options: limit, before, after.
  - Options are forwarded to Payload::list so API calls return the requested page.

- Migration
  - No breaking changes; existing calls still work.
  - To paginate: ApiKey->list(['limit' => 50, 'after' => $cursor]) or Contact->list($audienceId, ['before' => $cursor]).

<!-- End of auto-generated description by cubic. -->

