### PR TITLE
feat: Add topics resource

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -16,6 +16,7 @@ use Resend\Service\ServiceFactory;
  * @property Service\Contact $contacts
  * @property Service\Domain $domains
  * @property Service\Email $emails
+ * @property Service\Topic $topics
  */
 class Client implements ClientContract
 {

--- a/src/Service/Email.php
+++ b/src/Service/Email.php
@@ -9,7 +9,7 @@ class Email extends Service
     /**
      * Retrieve an email with the given ID.
      *
-     * @see https://resend.com/docs/api-reference/emails/retrieve-email#path-parameters
+     * @see https://resend.com/docs/api-reference/emails/retrieve-email
      */
     public function get(string $id): \Resend\Email
     {

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -11,6 +11,7 @@ use Resend\Contracts\Transporter;
 use Resend\Domain;
 use Resend\Email;
 use Resend\Resource;
+use Resend\Topic;
 
 abstract class Service
 {
@@ -24,6 +25,7 @@ abstract class Service
         'contacts' => Contact::class,
         'domains' => Domain::class,
         'emails' => Email::class,
+        'topics' => Topic::class,
     ];
 
     /**

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -19,6 +19,7 @@ class ServiceFactory
         'contacts' => Contact::class,
         'domains' => Domain::class,
         'emails' => Email::class,
+        'topics' => Topic::class,
     ];
 
     /**

--- a/src/Service/Topic.php
+++ b/src/Service/Topic.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Resend\Service;
+
+use Resend\ValueObjects\Transporter\Payload;
+
+class Topic extends Service
+{
+    /**
+     * Retrieve an email with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/topics/get-topic
+     */
+    public function get(string $id): \Resend\Topic
+    {
+        $payload = Payload::get('topics', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('topics', $result);
+    }
+
+    /**
+     * Create and email topics to segment your audience.
+     *
+     * @see https://resend.com/docs/api-reference/topics/create-topic
+     */
+    public function create(array $parameters, array $options = []): \Resend\Topic
+    {
+        $payload = Payload::create('topics', $parameters, $options);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('topics', $result);
+    }
+
+    /**
+     * Retrieve a list of topics.
+     *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
+     *
+     * @see https://resend.com/docs/api-reference/topics/list-topics
+     */
+    public function list(array $options = []): \Resend\Collection
+    {
+        $payload = Payload::list('topics', $options);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('topics', $result);
+    }
+
+    /**
+     * Update an existing topic.
+     *
+     * @see https://resend.com/docs/api-reference/topics/update-topic
+     */
+    public function update(string $id, array $parameters): \Resend\Topic
+    {
+        $payload = Payload::update('topics', $id, $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('topics', $result);
+    }
+
+    /**
+     * Remove an existing topic.
+     *
+     * @see https://resend.com/docs/api-reference/topics/delete-topic
+     */
+    public function remove(string $id): \Resend\Topic
+    {
+        $payload = Payload::delete('topics', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('topics', $result);
+    }
+}

--- a/src/Service/Topic.php
+++ b/src/Service/Topic.php
@@ -7,7 +7,7 @@ use Resend\ValueObjects\Transporter\Payload;
 class Topic extends Service
 {
     /**
-    * Retrieve a topic with the given ID.
+     * Retrieve a topic with the given ID.
      *
      * @see https://resend.com/docs/api-reference/topics/get-topic
      */
@@ -21,7 +21,7 @@ class Topic extends Service
     }
 
     /**
-     * Create and email topics to segment your audience.
+     * Create a topic to segment your audience.
      *
      * @see https://resend.com/docs/api-reference/topics/create-topic
      */

--- a/src/Service/Topic.php
+++ b/src/Service/Topic.php
@@ -7,7 +7,7 @@ use Resend\ValueObjects\Transporter\Payload;
 class Topic extends Service
 {
     /**
-     * Retrieve an email with the given ID.
+    * Retrieve a topic with the given ID.
      *
      * @see https://resend.com/docs/api-reference/topics/get-topic
      */

--- a/src/Topic.php
+++ b/src/Topic.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Resend;
+
+/**
+ * @property string $id The unique identifier for the topic.
+ * @property string $object The type of object.
+ * @property string $name The topic name.
+ * @property string $default_subscription The default subscription preference for new contacts. Possible values: `opt_in` or `opt_out`.
+ * @property string $description The topic description.
+ */
+class Topic extends Resource
+{
+    //
+}

--- a/tests/Fixtures/Topic.php
+++ b/tests/Fixtures/Topic.php
@@ -1,0 +1,35 @@
+<?php
+
+function topic(): array
+{
+    return [
+        'id' => 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+        'name' => 'Newsletter',
+        'description' => 'Weekly newsletter updates',
+        'default_subscription' => 'opt_in',
+        'created_at' => '2023-04-07T23:13:52.669661+00:00',
+    ];
+}
+
+function topics(): array
+{
+    return [
+        'object' => 'list',
+        'data' => [
+            [
+                'id' => 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+                'name' => 'Newsletter',
+                'description' => 'Weekly newsletter updates',
+                'default_subscription' => 'opt_in',
+                'created_at' => '2023-04-07T23:13:52.669661+00:00',
+            ],
+            [
+                'id' => 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+                'name' => 'Product Updates',
+                'description' => 'Product announcements and updates',
+                'default_subscription' => 'opt_out',
+                'created_at' => '2023-04-07T23:13:20.417116+00:00',
+            ],
+        ],
+    ];
+}

--- a/tests/Service/Topic.php
+++ b/tests/Service/Topic.php
@@ -1,0 +1,44 @@
+<?php
+
+use Resend\Collection;
+use Resend\Topic;
+
+it('can get a topic', function () {
+    $client = mockClient('GET', 'topics/b6d24b8e-af0b-4c3c-be0c-359bbd97381e', [], [], topic());
+
+    $result = $client->topics->get('b6d24b8e-af0b-4c3c-be0c-359bbd97381e');
+
+    expect($result)->toBeInstanceOf(Topic::class)
+        ->id->toBe('b6d24b8e-af0b-4c3c-be0c-359bbd97381e');
+});
+
+it('can create a topic resource', function () {
+    $client = mockClient('POST', 'topics', [
+        'name' => 'Newsletter',
+    ], [], topic());
+
+    $result = $client->topics->create([
+        'name' => 'Newsletter',
+    ]);
+
+    expect($result)->toBeInstanceOf(Topic::class)
+        ->id->toBe('b6d24b8e-af0b-4c3c-be0c-359bbd97381e');
+});
+
+it('can get a list of topic resources', function () {
+    $client = mockClient('GET', 'topics', [], [], topics());
+
+    $result = $client->topics->list();
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can remove a topic resource', function () {
+    $client = mockClient('DELETE', 'topics/b6d24b8e-af0b-4c3c-be0c-359bbd97381e', [], [], topic());
+
+    $result = $client->topics->remove('b6d24b8e-af0b-4c3c-be0c-359bbd97381e');
+
+    expect($result)->toBeInstanceOf(Topic::class)
+        ->id->toBe('b6d24b8e-af0b-4c3c-be0c-359bbd97381e');
+});


### PR DESCRIPTION
This PR adds the `topics` resource to the SDK.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add Topics support to the SDK with create, get, list, update, and delete operations. This exposes $client->topics and matches the Resend Topics API for audience segmentation.

- **New Features**
  - Topic service with get/create/list/update/remove.
  - Topic model with id, object, name, default_subscription, description.
  - Wired into Client and ServiceFactory to enable $client->topics.

- **Refactors**
  - Hardened test HTTP mock: validates method, User-Agent, path, body, and Idempotency-Key.
  - Fixed Email service docs link.

<!-- End of auto-generated description by cubic. -->

