### PR TITLE
feat: add improved contacts service

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -34,17 +34,6 @@ class Client implements ClientContract
     }
 
     /**
-     * Send an email with the given parameters.
-     *
-     * @deprecated
-     * @see https://resend.com/docs/api-reference/emails/send-email#body-parameters
-     */
-    public function sendEmail(array $parameters): Email
-    {
-        return $this->emails->send($parameters);
-    }
-
-    /**
      * Magic method to retrieve a service by name.
      */
     public function __get(string $name)

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.22.0';
+    public const VERSION = '1.0.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -2,25 +2,18 @@
 
 namespace Resend\Service;
 
-use InvalidArgumentException;
 use Resend\ValueObjects\Transporter\Payload;
 
 class Contact extends Service
 {
     /**
-     * Retrieve a single contact from an audience.
+     * Retrieve a single contact by ID or email.
      *
      * @see https://resend.com/docs/api-reference/contacts/get-contact
      */
-    public function get(string $audienceId, ?string $id = null, ?string $email = null): \Resend\Contact
+    public function get(string $idOrEmail): \Resend\Contact
     {
-        if (! ($id xor $email)) {
-            throw new InvalidArgumentException('You must provide either an ID or an email, but not both.');
-        }
-
-        $idOrEmail = $id ?? $email;
-
-        $payload = Payload::get("audiences/$audienceId/contacts", $idOrEmail);
+        $payload = Payload::get('contacts', $idOrEmail);
 
         $result = $this->transporter->request($payload);
 
@@ -28,13 +21,13 @@ class Contact extends Service
     }
 
     /**
-     * Add a contact to an audience.
+     * Create a contact.
      *
      * @see https://resend.com/docs/api-reference/contacts/create-contact
      */
-    public function create(string $audienceId, array $parameters): \Resend\Contact
+    public function create(array $parameters): \Resend\Contact
     {
-        $payload = Payload::create("audiences/$audienceId/contacts", $parameters);
+        $payload = Payload::create('contacts', $parameters);
 
         $result = $this->transporter->request($payload);
 
@@ -42,16 +35,16 @@ class Contact extends Service
     }
 
     /**
-     * List all contacts from an audience.
+     * List all contacts.
      *
      * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
      * @return \Resend\Collection<\Resend\Contact>
      *
      * @see https://resend.com/docs/api-reference/contacts/list-contacts
      */
-    public function list(string $audienceId, array $options = []): \Resend\Collection
+    public function list(array $options = []): \Resend\Collection
     {
-        $payload = Payload::list("audiences/$audienceId/contacts", $options);
+        $payload = Payload::list('contacts', $options);
 
         $result = $this->transporter->request($payload);
 
@@ -59,13 +52,13 @@ class Contact extends Service
     }
 
     /**
-     * Update a contact in an audience.
+     * Update a contact by ID or email.
      *
      * @see https://resend.com/docs/api-reference/contacts/update-contacts
      */
-    public function update(string $audienceId, string $id, array $parameters): \Resend\Contact
+    public function update(string $idOrEmail, array $parameters): \Resend\Contact
     {
-        $payload = Payload::update("audiences/$audienceId/contacts", $id, $parameters);
+        $payload = Payload::update('contacts', $idOrEmail, $parameters);
 
         $result = $this->transporter->request($payload);
 
@@ -73,13 +66,13 @@ class Contact extends Service
     }
 
     /**
-     * Remove a contact from an audience.
+     * Remove a contact by ID or email.
      *
      * @see https://resend.com/docs/api-reference/contacts/delete-contact
      */
-    public function remove(string $audienceId, string $id): \Resend\Contact
+    public function remove(string $idOrEmail): \Resend\Contact
     {
-        $payload = Payload::delete("audiences/$audienceId/contacts", $id);
+        $payload = Payload::delete('contacts', $idOrEmail);
 
         $result = $this->transporter->request($payload);
 

--- a/tests/Client.php
+++ b/tests/Client.php
@@ -1,24 +1,6 @@
 <?php
 
-use Resend\Email;
 use Resend\Service\ApiKey;
-
-test('send email', function () {
-    $client = mockClient('POST', 'emails', [
-        'to' => 'test@resend.com',
-    ], [], email());
-
-    // Use deprecated method until it is removed...
-    $result = $client->sendEmail([
-        'to' => 'test@resend.com',
-    ]);
-
-    expect($result)
-        ->toBeInstanceOf(Email::class)
-        ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794')
-        ->from->toBe('onboarding@resend.dev')
-        ->to->toBe('user@gmail.com');
-});
 
 test('service is created when required through property', function () {
     $resend = Resend::client('foo');

--- a/tests/Service/Contact.php
+++ b/tests/Service/Contact.php
@@ -1,48 +1,32 @@
 <?php
 
-use Resend\Client;
 use Resend\Collection;
 use Resend\Contact;
-use Resend\Contracts\Transporter;
 
-it('can get a contact by id in an audience', function () {
-    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], [], contact());
+it('can get a contact by id', function () {
+    $client = mockClient('GET', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], [], contact());
 
-    $result = $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3');
+    $result = $client->contacts->get('e169aa45-1ecf-4183-9955-b1499d5701d3');
 
     expect($result)->toBeInstanceOf(Contact::class)
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
 });
 
-it('can get a contact by email in an audience', function () {
-    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/steve.wozniak@gmail.com', [], [], contact());
+it('can get a contact by email', function () {
+    $client = mockClient('GET', 'contacts/steve.wozniak@gmail.com', [], [], contact());
 
-    $result = $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', email: 'steve.wozniak@gmail.com');
+    $result = $client->contacts->get('steve.wozniak@gmail.com');
 
     expect($result)->toBeInstanceOf(Contact::class)
         ->email->toBe('steve.wozniak@gmail.com');
 });
 
-it('throws an error when getting a contact by email and id in an audience', function () {
-    $transporter = Mockery::mock(Transporter::class);
-    $client = new Client($transporter);
-
-    $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3', email: 'steve.wozniak@gmail.com');
-})->throws(InvalidArgumentException::class, 'You must provide either an ID or an email, but not both.');
-
-it('throws an error when an id or email is not provided to get a contact in an audience', function () {
-    $transporter = Mockery::mock(Transporter::class);
-    $client = new Client($transporter);
-
-    $client->contacts->get(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf');
-})->throws(InvalidArgumentException::class, 'You must provide either an ID or an email, but not both.');
-
-it('can create a contact in an audience', function () {
-    $client = mockClient('POST', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts', [
+it('can create a contact', function () {
+    $client = mockClient('POST', 'contacts', [
         'email' => 'steve.wozniak@gmail.com',
     ], [], contact());
 
-    $result = $client->contacts->create('78261eea-8f8b-4381-83c6-79fa7120f1cf', [
+    $result = $client->contacts->create([
         'email' => 'steve.wozniak@gmail.com',
     ]);
 
@@ -50,21 +34,21 @@ it('can create a contact in an audience', function () {
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
 });
 
-it('can get a list of contacts in an audience', function () {
-    $client = mockClient('GET', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts', [], [], contacts());
+it('can get a list of contacts', function () {
+    $client = mockClient('GET', 'contacts', [], [], contacts());
 
-    $result = $client->contacts->list('78261eea-8f8b-4381-83c6-79fa7120f1cf');
+    $result = $client->contacts->list();
 
     expect($result)->toBeInstanceOf(Collection::class)
         ->data->toBeArray();
 });
 
-it('can update a contact in an audience', function () {
-    $client = mockClient('PATCH', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [
+it('can update a contact by id', function () {
+    $client = mockClient('PATCH', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [
         'first_name' => 'Steve',
     ], [], contact());
 
-    $result = $client->contacts->update('78261eea-8f8b-4381-83c6-79fa7120f1cf', 'e169aa45-1ecf-4183-9955-b1499d5701d3', [
+    $result = $client->contacts->update('e169aa45-1ecf-4183-9955-b1499d5701d3', [
         'first_name' => 'Steve',
     ]);
 
@@ -72,19 +56,32 @@ it('can update a contact in an audience', function () {
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
 });
 
-it('can remove a contact in an audience', function () {
-    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], [], contact());
+it('can update a contact by email', function () {
+    $client = mockClient('PATCH', 'contacts/steve.wozniak@gmail.com', [
+        'first_name' => 'Steve',
+    ], [], contact());
 
-    $result = $client->contacts->remove(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'e169aa45-1ecf-4183-9955-b1499d5701d3');
+    $result = $client->contacts->update('steve.wozniak@gmail.com', [
+        'first_name' => 'Steve',
+    ]);
 
     expect($result)->toBeInstanceOf(Contact::class)
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
 });
 
-it('can remove a contact in an audience using an email', function () {
-    $client = mockClient('DELETE', 'audiences/78261eea-8f8b-4381-83c6-79fa7120f1cf/contacts/acme@example.com', [], [], contact());
+it('can remove a contact by id', function () {
+    $client = mockClient('DELETE', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3', [], [], contact());
 
-    $result = $client->contacts->remove(audienceId: '78261eea-8f8b-4381-83c6-79fa7120f1cf', id: 'acme@example.com');
+    $result = $client->contacts->remove('e169aa45-1ecf-4183-9955-b1499d5701d3');
+
+    expect($result)->toBeInstanceOf(Contact::class)
+        ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
+});
+
+it('can remove a contact by email', function () {
+    $client = mockClient('DELETE', 'contacts/steve.wozniak@gmail.com', [], [], contact());
+
+    $result = $client->contacts->remove('steve.wozniak@gmail.com');
 
     expect($result)->toBeInstanceOf(Contact::class)
         ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');

--- a/tests/Service/Email.php
+++ b/tests/Service/Email.php
@@ -12,6 +12,22 @@ it('can get an email resource', function () {
         ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794');
 });
 
+it('can send an email', function () {
+    $client = mockClient('POST', 'emails', [
+        'to' => 'test@resend.com',
+    ], [], email());
+
+    $result = $client->emails->send([
+        'to' => 'test@resend.com',
+    ]);
+
+    expect($result)
+        ->toBeInstanceOf(Email::class)
+        ->id->toBe('49a3999c-0ce1-4ea6-ab68-afcd6dc2e794')
+        ->from->toBe('onboarding@resend.dev')
+        ->to->toBe('user@gmail.com');
+});
+
 it('can send an email with an idempotency key', function () {
     $client = mockClient('POST', 'emails', [
         'to' => 'test@resend.com',


### PR DESCRIPTION
This PR updates the `Contacts` service to use the new Contacts API endpoint. This causes a breaking change.

Since this is a breaking change, the SDK will be updated to `v1.0.0` and the deprecated `$resend->sendEmail` method will be removed in favor of `$resend->emails->send()`.
    


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Contacts service to use the new top-level /contacts API, removing audience-scoped endpoints and changing method signatures. Bumps SDK to 1.0.0 and removes the deprecated sendEmail; use emails->send() instead.

- **Migration**
  - Replace client->sendEmail(...) with client->emails->send(...).
  - Remove audienceId from Contacts calls. Pass a contact ID or email instead.
  - New signatures: get(idOrEmail), create(parameters), list(options), update(idOrEmail, parameters), remove(idOrEmail).
  - API paths now use /contacts instead of /audiences/{audienceId}/contacts.

<sup>Written for commit 7e9db86. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



