### PR TITLE
feat: add support for webhooks API

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -16,6 +16,7 @@ use Resend\Service\ServiceFactory;
  * @property Service\Contact $contacts
  * @property Service\Domain $domains
  * @property Service\Email $emails
+ * @property Service\Webhook $webhooks
  */
 class Client implements ClientContract
 {

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -6,7 +6,6 @@ namespace Resend;
  * @property string $id The unique identifier for the domain.
  * @property string $name The domain name.
  * @property string $status The verification status of the domain.
- * @property string $capability The capability of the domain.
  * @property string $created_at Time at which the domain was created.
  * @property string $region The region the domain is located in.
  * @property array $records The list of DNS records to add to your domain.

--- a/src/Domain.php
+++ b/src/Domain.php
@@ -5,7 +5,10 @@ namespace Resend;
 /**
  * @property string $id The unique identifier for the domain.
  * @property string $name The domain name.
+ * @property string $status The verification status of the domain.
+ * @property string $capability The capability of the domain.
  * @property string $created_at Time at which the domain was created.
+ * @property string $region The region the domain is located in.
  * @property array $records The list of DNS records to add to your domain.
  */
 class Domain extends Resource

--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '0.22.0';
+    public const VERSION = '0.23.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -11,6 +11,7 @@ use Resend\Contracts\Transporter;
 use Resend\Domain;
 use Resend\Email;
 use Resend\Resource;
+use Resend\Webhook;
 
 abstract class Service
 {
@@ -24,6 +25,7 @@ abstract class Service
         'contacts' => Contact::class,
         'domains' => Domain::class,
         'emails' => Email::class,
+        'webhooks' => Webhook::class,
     ];
 
     /**

--- a/src/Service/ServiceFactory.php
+++ b/src/Service/ServiceFactory.php
@@ -19,6 +19,7 @@ class ServiceFactory
         'contacts' => Contact::class,
         'domains' => Domain::class,
         'emails' => Email::class,
+        'webhooks' => Webhook::class,
     ];
 
     /**

--- a/src/Service/Webhook.php
+++ b/src/Service/Webhook.php
@@ -83,7 +83,7 @@ class Webhook extends Service
     /**
      * Determine if the incoming webhook request is valid.
      */
-    public function verify(string $payload, array $headers, string $secret, ?int $tolerance = null): bool
+    public function verify(string $payload, array $headers, string $secret, ?int $tolerance = 300): bool
     {
         return WebhookSignature::verify($payload, $headers, $secret, $tolerance);
     }

--- a/src/Service/Webhook.php
+++ b/src/Service/Webhook.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Resend\Service;
+
+use Resend\ValueObjects\Transporter\Payload;
+
+class Webhook extends Service
+{
+    /**
+     * Retrieve a webhook with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/webhooks/get-webhook
+     */
+    public function get(string $id): \Resend\Webhook
+    {
+        $payload = Payload::get('webhooks', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('webhooks', $result);
+    }
+
+    /**
+     * Create a new webhook.
+     *
+     * @see https://resend.com/docs/api-reference/webhooks/create-webhook
+     */
+    public function create(array $parameters): \Resend\Webhook
+    {
+        $payload = Payload::create('webhooks', $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('webhooks', $result);
+    }
+
+    /**
+     * List all webhooks.
+     *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
+     * @return \Resend\Collection<\Resend\Webhook>
+     *
+     * @see https://resend.com/docs/api-reference/webhooks/list-webhooks
+     */
+    public function list(array $options = []): \Resend\Collection
+    {
+        $payload = Payload::list('webhooks', $options);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('webhooks', $result);
+    }
+
+    /**
+     * Remove a webhook with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/webhooks/delete-webhook
+     */
+    public function remove(string $id): \Resend\Webhook
+    {
+        $payload = Payload::delete('webhooks', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('webhooks', $result);
+    }
+}

--- a/src/Service/Webhook.php
+++ b/src/Service/Webhook.php
@@ -3,6 +3,7 @@
 namespace Resend\Service;
 
 use Resend\ValueObjects\Transporter\Payload;
+use Resend\WebhookSignature;
 
 class Webhook extends Service
 {
@@ -77,5 +78,13 @@ class Webhook extends Service
         $result = $this->transporter->request($payload);
 
         return $this->createResource('webhooks', $result);
+    }
+
+    /**
+     * Determine if the incoming webhook request is valid.
+     */
+    public function verify(string $payload, array $headers, string $secret, ?int $tolerance = null): bool
+    {
+        return WebhookSignature::verify($payload, $headers, $secret, $tolerance);
     }
 }

--- a/src/Service/Webhook.php
+++ b/src/Service/Webhook.php
@@ -52,6 +52,20 @@ class Webhook extends Service
     }
 
     /**
+     * Update a webhook with the given ID.
+     *
+     * @see https://resend.com/docs/api-reference/webhooks/update-webhook
+     */
+    public function update(string $id, array $parameters): \Resend\Webhook
+    {
+        $payload = Payload::update('webhooks', $id, $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('webhooks', $result);
+    }
+
+    /**
      * Remove a webhook with the given ID.
      *
      * @see https://resend.com/docs/api-reference/webhooks/delete-webhook

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Resend;
+
+/**
+ * @property string $object The type of object.
+ * @property string $id The unique identifier for the webhook.
+ * @property string $created_at Time at which the email was created.
+ * @property string $status The current status of the webhook.
+ * @property string $endpoint The URL where webhook events will be sent.
+ * @property array<int, string> $events The array of event types the webhook is subscribed to.
+ * @property string $signing_secret The signing secret used to verify this webhook.
+ */
+class Webhook extends Resource
+{
+    //
+}

--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -5,7 +5,7 @@ namespace Resend;
 /**
  * @property string $object The type of object.
  * @property string $id The unique identifier for the webhook.
- * @property string $created_at Time at which the email was created.
+ * @property string $created_at Time at which the webhook was created.
  * @property string $status The current status of the webhook.
  * @property string $endpoint The URL where webhook events will be sent.
  * @property array<int, string> $events The array of event types the webhook is subscribed to.

--- a/src/WebhookSignature.php
+++ b/src/WebhookSignature.php
@@ -6,7 +6,7 @@ use Resend\Exceptions\WebhookSignatureVerificationException;
 
 final class WebhookSignature
 {
-    public static function verify(string $payload, array $headers, string $secret, ?int $tolerance = null): bool
+    public static function verify(string $payload, array $headers, string $secret, ?int $tolerance = 300): bool
     {
         $secret = static::getSecret($secret);
 

--- a/tests/Fixtures/Webhook.php
+++ b/tests/Fixtures/Webhook.php
@@ -1,6 +1,37 @@
 <?php
 
-function webhook(?int $timestamp = null)
+function webhook()
+{
+    return [
+        'object' => 'webhook',
+        'id' => '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+        'created_at' => '2023-08-22T15:28:00.000Z',
+        'status' => 'enabled',
+        'endpoint' => 'https://webhook.example.com/handler',
+        'events' => ['email.sent', 'email.received'],
+        'signing_secret' => 'whsec_xxxxxxxxxx',
+    ];
+}
+
+function webhooks()
+{
+    return [
+        'object' => 'list',
+        'data' => [
+            [
+                'object' => 'webhook',
+                'id' => '4dd369bc-aa82-4ff3-97de-514ae3000ee0',
+                'created_at' => '2023-08-22T15:28:00.000Z',
+                'status' => 'enabled',
+                'endpoint' => 'https://webhook.example.com/handler',
+                'events' => ['email.sent', 'email.received'],
+                'signing_secret' => 'whsec_xxxxxxxxxx',
+            ],
+        ],
+    ];
+}
+
+function webhookRequest(?int $timestamp = null)
 {
     $payload = '{"test": 2432232315}';
     $secret = 'MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw';

--- a/tests/Service/Webhook.php
+++ b/tests/Service/Webhook.php
@@ -1,0 +1,46 @@
+<?php
+
+use Resend\Collection;
+use Resend\Webhook;
+
+it('can get a webhook resource', function () {
+    $client = mockClient('GET', 'webhooks/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], [], webhook());
+
+    $result = $client->webhooks->get('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+
+    expect($result)->toBeInstanceOf(Webhook::class)
+        ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+});
+
+it('can create a webhook resource', function () {
+    $client = mockClient('POST', 'webhooks', [
+        'endpoint' => 'https://webhook.example.com/handler',
+        'events' => ['email.sent', 'email.delivered', 'email.bounced'],
+    ], [], webhook());
+
+    $result = $client->webhooks->create([
+        'endpoint' => 'https://webhook.example.com/handler',
+        'events' => ['email.sent', 'email.delivered', 'email.bounced'],
+    ]);
+
+    expect($result)->toBeInstanceOf(Webhook::class)
+        ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+});
+
+it('can get a list of webhook resources', function () {
+    $client = mockClient('GET', 'webhooks', [], [], webhooks());
+
+    $result = $client->webhooks->list();
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
+it('can remove a webhook resource', function () {
+    $client = mockClient('DELETE', 'webhooks/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], [], webhook());
+
+    $result = $client->webhooks->remove('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+
+    expect($result)->toBeInstanceOf(Webhook::class)
+        ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+});

--- a/tests/Service/Webhook.php
+++ b/tests/Service/Webhook.php
@@ -36,6 +36,19 @@ it('can get a list of webhook resources', function () {
         ->data->toBeArray();
 });
 
+it('can update a webhook resource', function () {
+    $client = mockClient('PATCH', 'webhooks/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [
+        'status' => 'enabled',
+    ], [], webhook());
+
+    $result = $client->webhooks->update('4dd369bc-aa82-4ff3-97de-514ae3000ee0', [
+        'status' => 'enabled',
+    ]);
+
+    expect($result)->toBeInstanceOf(Webhook::class)
+        ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
+});
+
 it('can remove a webhook resource', function () {
     $client = mockClient('DELETE', 'webhooks/4dd369bc-aa82-4ff3-97de-514ae3000ee0', [], [], webhook());
 

--- a/tests/Service/Webhook.php
+++ b/tests/Service/Webhook.php
@@ -57,3 +57,11 @@ it('can remove a webhook resource', function () {
     expect($result)->toBeInstanceOf(Webhook::class)
         ->id->toBe('4dd369bc-aa82-4ff3-97de-514ae3000ee0');
 });
+
+it('can verify webhook requests', function () {
+    $webhook = webhookRequest(time());
+
+    $verified = Resend::client('re_123456')->webhooks->verify($webhook['payload'], $webhook['headers'], 'MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw', 300);
+
+    expect($verified)->toBeTrue();
+});

--- a/tests/WebhookSignature.php
+++ b/tests/WebhookSignature.php
@@ -9,7 +9,7 @@ beforeEach(function () {
 });
 
 it('returns a true value', function () {
-    $webhook = webhook(time());
+    $webhook = webhookRequest(time());
 
     $verified = WebhookSignature::verify($webhook['payload'], $webhook['headers'], $this->secret, 300);
 
@@ -17,14 +17,14 @@ it('returns a true value', function () {
 });
 
 it('throws an exception when a required header is missing', function () {
-    $webhook = webhook(time());
+    $webhook = webhookRequest(time());
     $headers = array_slice($webhook['headers'], 2, 1);
 
     WebhookSignature::verify($webhook['payload'], $headers, $this->secret, 300);
 })->throws(WebhookSignatureVerificationException::class);
 
 it('throws an exception for an incorrect signature version', function () {
-    $webhook = webhook(time());
+    $webhook = webhookRequest(time());
     $headers = array_merge($webhook['headers'], [
         'svix-signature' => 'signature',
     ]);
@@ -33,7 +33,7 @@ it('throws an exception for an incorrect signature version', function () {
 })->throws(WebhookSignatureVerificationException::class, 'No signatures found matching the expected signature');
 
 it('can remove the whsec_ prefix from the secret before verification', function () {
-    $webhook = webhook(time());
+    $webhook = webhookRequest(time());
 
     $verified = WebhookSignature::verify($webhook['payload'], $webhook['headers'], 'whsec_' . $this->secret, 300);
 
@@ -41,7 +41,7 @@ it('can remove the whsec_ prefix from the secret before verification', function 
 });
 
 it('throws an exception for an incorrect timestamp', function () {
-    $webhook = webhook(null);
+    $webhook = webhookRequest(null);
     $headers = array_merge($webhook['headers'], [
         'svix-timestamp' => 'September',
     ]);
@@ -50,7 +50,7 @@ it('throws an exception for an incorrect timestamp', function () {
 })->throws(WebhookSignatureVerificationException::class, 'Invalid timestamp');
 
 it('throws an exception for an older timestamp', function () {
-    $webhook = webhook(time());
+    $webhook = webhookRequest(time());
 
     $headers = array_merge($webhook['headers'], [
         'svix-timestamp' => time() - 400,
@@ -60,7 +60,7 @@ it('throws an exception for an older timestamp', function () {
 })->throws(WebhookSignatureVerificationException::class, 'Message timestamp too old');
 
 it('throws an exception for a newer timestamp', function () {
-    $webhook = webhook(time());
+    $webhook = webhookRequest(time());
 
     $headers = array_merge($webhook['headers'], [
         'svix-timestamp' => time() + 400,


### PR DESCRIPTION
This PR adds support for the `webhooks` API and also adds a `verify` helper method to the `webhooks` service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full Webhooks API support with CRUD endpoints and request verification, so you can manage webhooks and securely handle incoming events. Bumps SDK version to 0.23.0.

- **New Features**
  - Webhooks service: get, create, list (limit/before/after), update, remove.
  - verify(payload, headers, secret, tolerance?) to validate Svix-signed requests.
  - Webhook resource with id, status, endpoint, events, signing_secret, created_at.
  - Client exposes $webhooks; service registry and factory updated.
  - Domain resource adds status, capability, and region fields.

<!-- End of auto-generated description by cubic. -->

