### PR TITLE
feat: Add support for contact topics

### DIFF
--- a/src/Contacts/Topic.php
+++ b/src/Contacts/Topic.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Resend\Contacts;
+
+use Resend\Resource;
+
+/**
+ * @property string $id The unique identifier for the contact topic.
+ * @property string $name The contact topic name.
+ * @property string $description The contact topic description.
+ * @property string $subscription The subscription preference for the contact topic. Possible values: `opt_in` or `opt_out`.
+ */
+class Topic extends Resource
+{
+    //
+}

--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -11,7 +11,7 @@ class Contact extends Service
     public Topic $topics;
 
     /**
-     * Create a new email service instance with the given transport.
+     * Create a new contact service instance with the given transport.
      */
     public function __construct(Transporter $transporter)
     {

--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -2,10 +2,24 @@
 
 namespace Resend\Service;
 
+use Resend\Contracts\Transporter;
+use Resend\Service\Contacts\Topic;
 use Resend\ValueObjects\Transporter\Payload;
 
 class Contact extends Service
 {
+    public Topic $topics;
+
+    /**
+     * Create a new email service instance with the given transport.
+     */
+    public function __construct(Transporter $transporter)
+    {
+        $this->topics = new Topic($transporter);
+
+        parent::__construct($transporter);
+    }
+
     /**
      * Retrieve a single contact by ID or email.
      *

--- a/src/Service/Contacts/Topic.php
+++ b/src/Service/Contacts/Topic.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Resend\Service\Contacts;
+
+use Resend\Service\Service;
+use Resend\ValueObjects\Transporter\Payload;
+
+class Topic extends Service
+{
+    /**
+     * Retrieve a list of topics subscriptions for a contact.
+     *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
+     * @return \Resend\Collection<\Resend\Contacts\Topic>
+     *
+     * @see https://resend.com/docs/api-reference/contacts/get-contact-topics
+     */
+    public function get(string $contactId): \Resend\Collection
+    {
+        $payload = Payload::list("contacts/$contactId/topics");
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('contact-topics', $result);
+    }
+
+    /**
+     * Update topic subscriptions for a contact.
+     *
+     * @see https://resend.com/docs/api-reference/contacts/update-contact-topics
+     */
+    public function update(string $contactId, array $parameters): \Resend\Contact
+    {
+        $payload = Payload::update('contacts', "$contactId/topics", $parameters);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('contacts', $result);
+    }
+}

--- a/src/Service/Service.php
+++ b/src/Service/Service.php
@@ -8,6 +8,7 @@ use Resend\Broadcast;
 use Resend\Collection;
 use Resend\Contact;
 use Resend\ContactProperty;
+use Resend\Contacts\Topic as ContactTopic;
 use Resend\Contracts\Transporter;
 use Resend\Domain;
 use Resend\Email;
@@ -31,6 +32,7 @@ abstract class Service
         'broadcasts' => Broadcast::class,
         'contacts' => Contact::class,
         'contact-properties' => ContactProperty::class,
+        'contact-topics' => ContactTopic::class,
         'domains' => Domain::class,
         'receiving' => Receiving::class,
         'emails' => Email::class,

--- a/tests/Fixtures/Contacts/Topic.php
+++ b/tests/Fixtures/Contacts/Topic.php
@@ -1,0 +1,36 @@
+<?php
+
+function contactTopic(): array
+{
+    return [
+        'id' => 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+        'name' => 'Newsletter',
+        'description' => 'Weekly newsletter updates',
+        'subscription' => 'opt_in',
+        'created_at' => '2023-04-07T23:13:52.669661+00:00',
+    ];
+}
+
+function contactTopics(): array
+{
+    return [
+        'object' => 'list',
+        'has_more' => false,
+        'data' => [
+            [
+                'id' => 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+                'name' => 'Newsletter',
+                'description' => 'Weekly newsletter updates',
+                'subscription' => 'opt_in',
+                'created_at' => '2023-04-07T23:13:52.669661+00:00',
+            ],
+            [
+                'id' => 'ac7503ac-e027-4aea-94b3-b0acd46f65f9',
+                'name' => 'Product Updates',
+                'description' => 'Product announcements and updates',
+                'subscription' => 'opt_out',
+                'created_at' => '2023-04-07T23:13:20.417116+00:00',
+            ],
+        ],
+    ];
+}

--- a/tests/Service/Contacts/Topic.php
+++ b/tests/Service/Contacts/Topic.php
@@ -1,0 +1,46 @@
+<?php
+
+use Resend\Collection;
+use Resend\Contact;
+use Resend\Contacts\Topic;
+
+it('can get a list of topic resources for a contact by ID', function () {
+    $client = mockClient('GET', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3/topics', [], [], contactTopics());
+
+    $result = $client->contacts->topics->get('e169aa45-1ecf-4183-9955-b1499d5701d3');
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+
+    expect($result->data[0])->toBeInstanceOf(Topic::class);
+});
+
+it('can get a list of topic resources for a contact by email', function () {
+    $client = mockClient('GET', 'contacts/steve.wozniak@gmail.com/topics', [], [], contactTopics());
+
+    $result = $client->contacts->topics->get('steve.wozniak@gmail.com');
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+
+    expect($result->data[0])->toBeInstanceOf(Topic::class);
+});
+
+it('can update topic resources for a contact by ID', function () {
+    $client = mockClient('PATCH', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3/topics', [
+        [
+            'id' => 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+            'subscription' => 'opt_out',
+        ],
+    ], [], contact());
+
+    $result = $client->contacts->topics->update('e169aa45-1ecf-4183-9955-b1499d5701d3', [
+        [
+            'id' => 'b6d24b8e-af0b-4c3c-be0c-359bbd97381e',
+            'subscription' => 'opt_out',
+        ],
+    ]);
+
+    expect($result)->toBeInstanceOf(Contact::class)
+        ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
+});

--- a/tests/Service/Topic.php
+++ b/tests/Service/Topic.php
@@ -34,6 +34,20 @@ it('can get a list of topic resources', function () {
         ->data->toBeArray();
 });
 
+it('can update a topic resource', function () {
+    $client = mockClient('PATCH', 'topics/b6d24b8e-af0b-4c3c-be0c-359bbd97381e', [
+        'name' => 'Weekly Newsletter',
+        'description' => 'Weekly newsletter for our subscribers',
+    ], [], topic());
+
+    $result = $client->topics->update('b6d24b8e-af0b-4c3c-be0c-359bbd97381e', [
+        'name' => 'Weekly Newsletter',
+        'description' => 'Weekly newsletter for our subscribers',
+    ]);
+
+    expect($result)->toBeInstanceOf(Topic::class);
+});
+
 it('can remove a topic resource', function () {
     $client = mockClient('DELETE', 'topics/b6d24b8e-af0b-4c3c-be0c-359bbd97381e', [], [], topic());
 


### PR DESCRIPTION
This PR adds support for the contact topics API endpoints.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for contact topics so you can list and update a contact’s topic subscriptions. Exposes contacts->topics methods via a new Contacts.Topic service and adds the Topic resource.

- **New Features**
  - New Contacts.Topic service.
  - contacts->topics->get(idOrEmail) returns Collection<Resend\Contacts\Topic>.
  - contacts->topics->update(idOrEmail, [{id, subscription}]) returns Resend\Contact.
  - Service map updated to include 'contact-topics'.

<sup>Written for commit c60dfe6748fa57c4d18a81ddf9a535be04012b87. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





