### PR TITLE
feat: Add support for contact segments

### DIFF
--- a/src/Service/Contact.php
+++ b/src/Service/Contact.php
@@ -2,10 +2,24 @@
 
 namespace Resend\Service;
 
+use Resend\Contracts\Transporter;
+use Resend\Service\Contacts\Segment;
 use Resend\ValueObjects\Transporter\Payload;
 
 class Contact extends Service
 {
+    public Segment $segments;
+
+    /**
+     * Create a new email service instance with the given transport.
+     */
+    public function __construct(Transporter $transporter)
+    {
+        $this->segments = new Segment($transporter);
+
+        parent::__construct($transporter);
+    }
+
     /**
      * Retrieve a single contact by ID or email.
      *

--- a/src/Service/Contacts/Segment.php
+++ b/src/Service/Contacts/Segment.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Resend\Service\Contacts;
+
+use Resend\Service\Service;
+use Resend\ValueObjects\Transporter\Payload;
+
+class Segment extends Service
+{
+    public function add(string $contact, string $segmentId): \Resend\Segment
+    {
+        $payload = Payload::create("contacts/$contact/segments/$segmentId", []);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('segments', $result);
+    }
+
+    /**
+     * Retrieve a list of segments for the given contact ID.
+     *
+     * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
+     * @return \Resend\Collection<\Resend\Segment>
+     *
+     * @see https://resend.com/docs/api-reference/contacts/list-contact-segments
+     */
+    public function list(string $contactId, array $options = []): \Resend\Collection
+    {
+        $payload = Payload::list("contacts/$contactId/segments", $options);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('segments', $result);
+    }
+
+    public function remove(string $contact, string $segmentId): \Resend\Segment
+    {
+        $payload = Payload::delete("contacts/$contact/segments", $segmentId);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('segments', $result);
+    }
+}

--- a/src/Service/Topic.php
+++ b/src/Service/Topic.php
@@ -38,6 +38,7 @@ class Topic extends Service
      * Retrieve a list of topics.
      *
      * @param array{'limit'?: int, 'before'?: string, 'after'?: string} $options
+     * @return \Resend\Collection<\Resend\Topic>
      *
      * @see https://resend.com/docs/api-reference/topics/list-topics
      */

--- a/tests/Service/Contacts/Segment.php
+++ b/tests/Service/Contacts/Segment.php
@@ -1,0 +1,39 @@
+<?php
+
+use Resend\Collection;
+use Resend\Segment;
+
+it('can add a contact to a segment', function () {
+    $client = mockClient('POST', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3/segments/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], [], segment());
+
+    $result = $client->contacts->segments->add(
+        contact: 'e169aa45-1ecf-4183-9955-b1499d5701d3',
+        segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf'
+    );
+
+    expect($result)->toBeInstanceOf(Segment::class)
+        ->id->toBe('78261eea-8f8b-4381-83c6-79fa7120f1cf');
+});
+
+it('can get a list of segments for a contact by ID', function () {
+    $client = mockClient('GET', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3/segments', [], [], segments());
+
+    $result = $client->contacts->segments->list('e169aa45-1ecf-4183-9955-b1499d5701d3');
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+
+    expect($result->data[0])->toBeInstanceOf(Segment::class);
+});
+
+it('can remove a contact from a segment', function () {
+    $client = mockClient('DELETE', 'contacts/e169aa45-1ecf-4183-9955-b1499d5701d3/segments/78261eea-8f8b-4381-83c6-79fa7120f1cf', [], [], segment());
+
+    $result = $client->contacts->segments->remove(
+        contact: 'e169aa45-1ecf-4183-9955-b1499d5701d3',
+        segmentId: '78261eea-8f8b-4381-83c6-79fa7120f1cf'
+    );
+
+    expect($result)->toBeInstanceOf(Segment::class)
+        ->id->toBe('78261eea-8f8b-4381-83c6-79fa7120f1cf');
+});


### PR DESCRIPTION
This PR adds support for contact segments

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds contact segment management so you can add, list, and remove segments for a contact. Exposes a new segments API under contacts and improves Topic list return docs.

- **New Features**
  - New Contacts\Segment service with add, list, and remove methods for contacts/{contactId}/segments.
  - Integrated into Contact; available as $client->contacts->segments.
  - Stronger returns: Segment and Collection<Segment>. Tests cover add, list, and remove.

- **Refactors**
  - Added return type docblock to Topic::list (Collection<Topic>).

<sup>Written for commit f5277c415301ee31b7a06792ff52a7d180a98ef5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

