### PR TITLE
feat(domains): add TrackingCAA record support

### DIFF
--- a/tests/Fixtures/Domain.php
+++ b/tests/Fixtures/Domain.php
@@ -50,6 +50,14 @@ function domain(): array
                 'ttl' => 'Auto',
                 'status' => 'not_started',
             ],
+            [
+                'record' => 'TrackingCAA',
+                'name' => '',
+                'type' => 'CAA',
+                'value' => '0 issue "amazon.com"',
+                'ttl' => 'Auto',
+                'status' => 'verified',
+            ],
         ],
     ];
 }

--- a/tests/Service/Domain.php
+++ b/tests/Service/Domain.php
@@ -12,6 +12,24 @@ it('can get a domain resource', function () {
         ->id->toBe('d91cd9bd-1176-453e-8fc1-35364d380206');
 });
 
+it('exposes the TrackingCAA record when present', function () {
+    $client = mockClient('GET', 'domains/d91cd9bd-1176-453e-8fc1-35364d380206', [], [], domain());
+
+    $result = $client->domains->get('d91cd9bd-1176-453e-8fc1-35364d380206');
+
+    $caaRecords = array_values(array_filter(
+        $result->records,
+        fn (array $record) => $record['record'] === 'TrackingCAA',
+    ));
+
+    expect($caaRecords)->toHaveCount(1)
+        ->and($caaRecords[0]['record'])->toBe('TrackingCAA')
+        ->and($caaRecords[0]['type'])->toBe('CAA')
+        ->and($caaRecords[0]['value'])->toBe('0 issue "amazon.com"')
+        ->and($caaRecords[0]['ttl'])->toBe('Auto')
+        ->and($caaRecords[0]['status'])->toBe('verified');
+});
+
 it('can create a domain resource', function () {
     $client = mockClient('POST', 'domains', [
         'name' => 'resend.dev',


### PR DESCRIPTION
## Summary

The Domains API now returns an additional DNS record on `POST /domains` and `GET /domains/:id` responses when:

1. A `tracking_subdomain` is configured on the domain, AND
2. The customer's root domain has CAA records that would otherwise prevent AWS from issuing a TLS certificate.

The new record looks like:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

The `Domain` resource already exposes `records` as a generic array, so no source change is required. This PR:

- Adds a `TrackingCAA` entry to the shared `domain()` fixture.
- Adds a service test that asserts the record surfaces from `domains->get()` with the expected `record`, `type`, `value`, `ttl`, and `status`.

## Test plan

- [x] Pest service test asserts the new fixture record round-trips through `Domain->records`
- [ ] CI runs full test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `TrackingCAA` DNS record support to Domains API responses to unblock AWS certificate issuance for tracking subdomains. Verifies the record surfaces correctly via `Domain->records`.

- **New Features**
  - Returns a `TrackingCAA` CAA record when a tracking subdomain is set and root CAA would block AWS issuance.
  - Updates the domain fixture and adds a service test to confirm the record appears via `domains->get()` with the expected fields.

<sup>Written for commit 0fc37fbf1f29f30d7ddbf83716284c1ad82e931f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

