### PR TITLE
chore: gh actions hardening

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,13 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     strategy:
       fail-fast: true
@@ -24,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }},
           extensions: dom, mbstring, zip,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
@@ -39,7 +39,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens the tests GitHub Actions workflow by pinning `actions/checkout`, `actions/cache`, and `shivammathur/setup-php` to commit SHAs, adding top‑level `contents: read` permissions, and setting a 10‑minute job timeout. Addresses DEV-662 findings (1 HIGH, 1 MED, 1 LOW) to reduce supply‑chain risk and prevent runaway runs.

<sup>Written for commit 0b64ea1cf5cf2bc9f004d67eea0ba94de5a3f8ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

