### PR TITLE
Add support for Guzzle 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     ],
     "require": {
         "php": "^8.1.0",
-        "guzzlehttp/guzzle": "^7.5"
+        "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+        "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+        "psr/http-client": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.13",

--- a/src/Transporters/HttpTransporter.php
+++ b/src/Transporters/HttpTransporter.php
@@ -81,7 +81,9 @@ class HttpTransporter implements Transporter
             return $callable();
         } catch (ClientExceptionInterface $clientException) {
             if ($clientException instanceof ClientException) {
-                $this->throwIfJsonError($clientException->getResponse(), $clientException->getResponse()->getBody()->getContents());
+                $response = $clientException->getResponse();
+
+                $this->throwIfJsonError($response, (string) $response->getBody());
             }
 
             throw new TransporterException($clientException);

--- a/tests/Transporters/HttpTransporter.php
+++ b/tests/Transporters/HttpTransporter.php
@@ -1,8 +1,10 @@
 <?php
 
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Client\ClientInterface;
 use Resend\Enums\Transporter\ContentType;
 use Resend\Exceptions\ErrorException;
@@ -105,6 +107,23 @@ test('request can handle client errors', function () {
             ->and($exception->getPrevious())->toBeInstanceOf(ConnectException::class);
     });
 });
+
+test('request can handle client exception json errors from the full response body', function () {
+    $payload = Payload::create('email', ['to' => 'test@resend.com']);
+    $request = new Request('POST', 'https://api.resend.com/email');
+    $body = Utils::streamFor(json_encode(['error' => 'Unauthorized']));
+
+    $body->getContents();
+
+    $response = new Response(401, ['Content-Type' => 'application/json'], $body);
+
+    $this->client
+        ->shouldReceive('sendRequest')
+        ->once()
+        ->andThrow(new ClientException('Unauthorized', $request, $response));
+
+    $this->http->request($payload);
+})->throws(ErrorException::class, 'Unauthorized');
 
 test('request can handle serialization errors', function () {
     $payload = Payload::create('email', ['to' => 'test@resend.com']);


### PR DESCRIPTION
Add support for Guzzle 8, adds in missing dependencies you were explicitly using but forgot to add explicit dependencies on, and bound the minimum versions to avoid super old versions.

---

FYI, the Guzzle 8.0.0 release is tentatively planned for early Q3. I am sending this PR as part of both validating that key packages can upgrade to Guzzle 8, and to actually get them upgraded. This package was identified as a key ecosystem package either because it is a widely used package or because it is a dependency of Laravel. This PR is not suitable to merge until Guzzle 8.0.0's actually released.