### PR TITLE
feat: add received_for to received email type

### DIFF
--- a/src/Emails/Receiving.php
+++ b/src/Emails/Receiving.php
@@ -16,6 +16,7 @@ use Resend\Resource;
  * @property null|array $bcc The email addresses of all blind carbon copy recipients.
  * @property null|array $cc The email addresses of all carbon copy recipients.
  * @property null|array $reply_to The reply to email address.
+ * @property array $received_for The addresses the email was received for (forwarding recipients).
  * @property string $message_id The unique identifier for the message.
  * @property null|array $headers The headers for the received email.
  * @property array $attachments The attachments for the email.

--- a/tests/Fixtures/Emails/Receiving.php
+++ b/tests/Fixtures/Emails/Receiving.php
@@ -14,6 +14,7 @@ function inboundEmail(): array
         'bcc' => [],
         'cc' => [],
         'reply_to' => [],
+        'received_for' => ['forwarded@example.com'],
         'message_id' => '<example+123>',
         'attachments' => [
             [

--- a/tests/Service/Emails/Receiving.php
+++ b/tests/Service/Emails/Receiving.php
@@ -9,7 +9,8 @@ it('can get an inbound email resource', function () {
     $result = $client->emails->receiving->get('4ef9a417-02e9-4d39-ad75-9611e0fcc33c');
 
     expect($result)->toBeInstanceOf(Receiving::class)
-        ->id->toBe('4ef9a417-02e9-4d39-ad75-9611e0fcc33c');
+        ->id->toBe('4ef9a417-02e9-4d39-ad75-9611e0fcc33c')
+        ->received_for->toBe(['forwarded@example.com']);
 });
 
 it('can get a list of inbound email resources', function () {


### PR DESCRIPTION
Adds the received_for field to the received email response type, matching the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `received_for` to the received email response to match the API and expose forwarding recipients. Updated fixtures and service tests to include and assert `received_for`.

<sup>Written for commit 14c361aadb73adb2ac19f8fc776534ee6a2cbc45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-php/pull/122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

