### PR TITLE
feat: document batch send tags

### DIFF
--- a/src/Service/Batch.php
+++ b/src/Service/Batch.php
@@ -20,9 +20,7 @@ class Batch extends Service
      *     reply_to?: string|array<int, string>,
      *     headers?: array<string, string>,
      *     topic_id?: string|null,
-     *     scheduled_at?: string,
      *     tags?: array<int, array{name: string, value: string}>,
-     *     attachments?: array<int, array{filename?: string, content?: string, path?: string, content_type?: string, content_id?: string}>,
      *     template?: array{id: string, variables?: array<string, string|int>}
      * }> $parameters
      * @param array{'idempotency_key'?: string, 'batch_validation'?: 'strict'|'permissive'} $options
@@ -55,9 +53,7 @@ class Batch extends Service
      *     reply_to?: string|array<int, string>,
      *     headers?: array<string, string>,
      *     topic_id?: string|null,
-     *     scheduled_at?: string,
      *     tags?: array<int, array{name: string, value: string}>,
-     *     attachments?: array<int, array{filename?: string, content?: string, path?: string, content_type?: string, content_id?: string}>,
      *     template?: array{id: string, variables?: array<string, string|int>}
      * }> $parameters
      * @param array{'idempotency_key'?: string, 'batch_validation'?: 'strict'|'permissive'} $options

--- a/src/Service/Batch.php
+++ b/src/Service/Batch.php
@@ -9,7 +9,23 @@ class Batch extends Service
     /**
      * Send a batch of emails with the given parameters.
      *
-     * @param array{'idempotency_key'?: string, 'batch_validation'?: string} $options
+     * @param array<int, array{
+     *     from: string,
+     *     to: string|array<int, string>,
+     *     subject?: string,
+     *     html?: string,
+     *     text?: string,
+     *     bcc?: string|array<int, string>,
+     *     cc?: string|array<int, string>,
+     *     reply_to?: string|array<int, string>,
+     *     headers?: array<string, string>,
+     *     topic_id?: string|null,
+     *     scheduled_at?: string,
+     *     tags?: array<int, array{name: string, value: string}>,
+     *     attachments?: array<int, array{filename?: string, content?: string, path?: string, content_type?: string, content_id?: string}>,
+     *     template?: array{id: string, variables?: array<string, string|int>}
+     * }> $parameters
+     * @param array{'idempotency_key'?: string, 'batch_validation'?: 'strict'|'permissive'} $options
      * @return \Resend\Collection<\Resend\Email>
      *
      * @see https://resend.com/docs/api-reference/emails/send-batch-emails
@@ -28,7 +44,23 @@ class Batch extends Service
     /**
      * Send a batch of emails with the given parameters.
      *
-     * @param array{'idempotency_key'?: string, 'batch_validation'?: string} $options
+     * @param array<int, array{
+     *     from: string,
+     *     to: string|array<int, string>,
+     *     subject?: string,
+     *     html?: string,
+     *     text?: string,
+     *     bcc?: string|array<int, string>,
+     *     cc?: string|array<int, string>,
+     *     reply_to?: string|array<int, string>,
+     *     headers?: array<string, string>,
+     *     topic_id?: string|null,
+     *     scheduled_at?: string,
+     *     tags?: array<int, array{name: string, value: string}>,
+     *     attachments?: array<int, array{filename?: string, content?: string, path?: string, content_type?: string, content_id?: string}>,
+     *     template?: array{id: string, variables?: array<string, string|int>}
+     * }> $parameters
+     * @param array{'idempotency_key'?: string, 'batch_validation'?: 'strict'|'permissive'} $options
      * @return \Resend\Collection<\Resend\Email>
      *
      * @see https://resend.com/docs/api-reference/emails/send-batch-emails

--- a/tests/Service/Batch.php
+++ b/tests/Service/Batch.php
@@ -50,6 +50,37 @@ it('can send a batch of emails with an idempotency key', function () {
         ->data->toBeArray();
 });
 
+it('can send a batch of emails with scheduled_at, tags, and attachments', function () {
+    $payload = [
+        [
+            'to' => 'test@resend.com',
+            'from' => 'noreply@resend.com',
+            'subject' => 'Acme',
+            'text' => 'it works!',
+            'scheduled_at' => '2024-08-05T11:52:01.858Z',
+            'tags' => [
+                [
+                    'name' => 'category',
+                    'value' => 'confirm_email',
+                ],
+            ],
+            'attachments' => [
+                [
+                    'filename' => 'sample.txt',
+                    'content' => 'dGVzdA==',
+                ],
+            ],
+        ],
+    ];
+
+    $client = mockClient('POST', 'emails/batch', $payload, [], batch());
+
+    $result = $client->batch->send($payload);
+
+    expect($result)->toBeInstanceOf(Collection::class)
+        ->data->toBeArray();
+});
+
 it('can send a batch of emails with batch validation', function () {
     $payload = [
         [

--- a/tests/Service/Batch.php
+++ b/tests/Service/Batch.php
@@ -50,24 +50,17 @@ it('can send a batch of emails with an idempotency key', function () {
         ->data->toBeArray();
 });
 
-it('can send a batch of emails with scheduled_at, tags, and attachments', function () {
+it('can send a batch of emails with tags', function () {
     $payload = [
         [
             'to' => 'test@resend.com',
             'from' => 'noreply@resend.com',
             'subject' => 'Acme',
             'text' => 'it works!',
-            'scheduled_at' => '2024-08-05T11:52:01.858Z',
             'tags' => [
                 [
                     'name' => 'category',
                     'value' => 'confirm_email',
-                ],
-            ],
-            'attachments' => [
-                [
-                    'filename' => 'sample.txt',
-                    'content' => 'dGVzdA==',
                 ],
             ],
         ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the batch send service to reflect API support for `tags` on individual emails within a batch request.

- Adds PHPDoc on `Batch::create()` and `Batch::send()` describing the per-email parameter shape, including `tags`
- Tightens `batch_validation` option typing to `'strict'|'permissive'`
- Adds a test confirming `tags` are forwarded in the batch request payload

## Notes

The PHP client is pass-through, so `tags` already worked at runtime. This change improves static analysis/IDE support and adds regression coverage.

## Test plan

- [x] `./vendor/bin/pest`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a7eff7a-c013-406f-a573-786a06b715f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a7eff7a-c013-406f-a573-786a06b715f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents per-email `tags` for batch send and narrows `batch_validation` typing to `'strict'|'permissive'`. Removes unsupported `scheduled_at` and `attachments` from batch docs and adds a test to ensure tags are forwarded.

- **Refactors**
  - Added PHPDoc to `Batch::create()` and `Batch::send()` documenting per-email tags and parameter shape.
  - Typed `batch_validation` as `'strict'|'permissive'`.
  - Added a test verifying tags are included in the batch payload.

<sup>Written for commit c573fe4e59beed07ad222989d2618b209d613310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-php/pull/127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

