### PR TITLE
chore: Update SDK version to 1.6.0

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '1.5.1';
+    public const VERSION = '1.6.0';
 
     /**
      * Creates a new Resend Client with the given API key.


### PR DESCRIPTION
This PR bumps the version to `1.6.0`.