### PR TITLE
feat: add broadcasts->cancel() method

### DIFF
--- a/src/Resend.php
+++ b/src/Resend.php
@@ -12,7 +12,7 @@ class Resend
     /**
      * The current SDK version.
      */
-    public const VERSION = '1.7.0';
+    public const VERSION = '1.8.0';
 
     /**
      * Creates a new Resend Client with the given API key.

--- a/src/Service/Broadcast.php
+++ b/src/Service/Broadcast.php
@@ -79,6 +79,15 @@ class Broadcast extends Service
         return $this->createResource('broadcasts', $result);
     }
 
+    public function cancel(string $id): \Resend\Broadcast
+    {
+        $payload = Payload::cancel('broadcasts', $id);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('broadcasts', $result);
+    }
+
     /**
      * Remove an existing broadcast.
      *

--- a/src/Service/Broadcast.php
+++ b/src/Service/Broadcast.php
@@ -79,6 +79,11 @@ class Broadcast extends Service
         return $this->createResource('broadcasts', $result);
     }
 
+    /**
+     * Cancel a queued or scheduled broadcast.
+     *
+     * @see https://resend.com/docs/api-reference/broadcasts/cancel-broadcast
+     */
     public function cancel(string $id): \Resend\Broadcast
     {
         $payload = Payload::cancel('broadcasts', $id);

--- a/tests/Service/Broadcast.php
+++ b/tests/Service/Broadcast.php
@@ -62,6 +62,15 @@ it('can send a broadcast resource', function () {
         ->id->toBe('559ac32e-9ef5-46fb-82a1-b76b840c0f7b');
 });
 
+it('can cancel a broadcast resource', function () {
+    $client = mockClient('POST', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/cancel', [], [], broadcast());
+
+    $result = $client->broadcasts->cancel('559ac32e-9ef5-46fb-82a1-b76b840c0f7b');
+
+    expect($result)->toBeInstanceOf(Broadcast::class)
+        ->id->toBe('559ac32e-9ef5-46fb-82a1-b76b840c0f7b');
+});
+
 it('can remove a broadcast resource', function () {
     $client = mockClient('DELETE', 'broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b', [], [], broadcast());
 


### PR DESCRIPTION
## Summary
- Adds `Broadcast::cancel($id)`, calling `POST /broadcasts/:id/cancel` via the shared `Payload::cancel()` helper (already used by `Email::cancel()`).

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122.

## Test plan
- [x] `vendor/bin/pest` — 183/183 passing, including the new `can cancel a broadcast resource` case
- [x] `php -l` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support to cancel a queued or scheduled broadcast via `Broadcast::cancel($id)` (POST /broadcasts/:id/cancel), mirroring `Email::cancel()`. Bumps SDK version to 1.8.0.

- **New Features**
  - Added `Broadcast::cancel($id)` using the shared `Payload::cancel()` helper; returns a `Broadcast` resource.
  - Added test and PHPDoc for `Broadcast::cancel()`.

- **Dependencies**
  - Bumped SDK version to `1.8.0`.

<sup>Written for commit 7a93e6589ab1c3c3db63492e8a1ad6a50e35e99c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-php/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

