### PR TITLE
feat(automations): duplicate endpoint

### DIFF
--- a/src/Service/Automation.php
+++ b/src/Service/Automation.php
@@ -116,6 +116,20 @@ class Automation extends Service
     }
 
     /**
+     * Duplicate an existing automation.
+     *
+     * @see https://resend.com/docs/api-reference/automations/duplicate-automation
+     */
+    public function duplicate(string $automationId): \Resend\Automation
+    {
+        $payload = Payload::create("automations/$automationId/duplicate", []);
+
+        $result = $this->transporter->request($payload);
+
+        return $this->createResource('automations', $result);
+    }
+
+    /**
      * Stop a running automation.
      *
      * @see https://resend.com/docs/api-reference/automations/stop-automation

--- a/tests/Service/Automation.php
+++ b/tests/Service/Automation.php
@@ -83,6 +83,18 @@ it('can remove an automation', function () {
         ->id->toBe('c9b16d4f-ba6c-4e2e-b044-6bf4404e57fd');
 });
 
+it('can duplicate an automation', function () {
+    $client = mockClient('POST', 'automations/c9b16d4f-ba6c-4e2e-b044-6bf4404e57fd/duplicate', [], [], [
+        'object' => 'automation',
+        'id' => 'e169aa45-1ecf-4183-9955-b1499d5701d3',
+    ]);
+
+    $result = $client->automations->duplicate('c9b16d4f-ba6c-4e2e-b044-6bf4404e57fd');
+
+    expect($result)->toBeInstanceOf(Automation::class)
+        ->id->toBe('e169aa45-1ecf-4183-9955-b1499d5701d3');
+});
+
 it('can stop an automation', function () {
     $client = mockClient('POST', 'automations/c9b16d4f-ba6c-4e2e-b044-6bf4404e57fd/stop', [], [], automation());
 


### PR DESCRIPTION
Adds `automations->duplicate($automationId)` for `POST /automations/{id}/duplicate`.

Resolves DEV-1705. Mirrors the existing `stop` pattern and resend-node https://github.com/resend/resend-node/pull/1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Automations duplicate support to the PHP SDK so clients can clone an existing automation. Previously there was no SDK method; now `automations->duplicate($automationId)` issues POST `/automations/{id}/duplicate` and returns the new Automation. Supports DEV-1705.

**Details**
- Implements `duplicate(string $automationId)` in the Automations service, mirroring the existing `stop` pattern (no request body).
- Adds a test for the POST path and Automation resource parsing.
- No breaking changes; consumers can start calling `duplicate` where needed.

<sup>Written for commit 65987a378c3018223b8b172d98a8a9daf004304d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-php/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

