### PR TITLE
fix(contacts): properties response shape

### DIFF
--- a/src/Contact.php
+++ b/src/Contact.php
@@ -9,6 +9,7 @@ namespace Resend;
  * @property null|string $last_name The last name of the contact.
  * @property bool $unsubscribed Whether the contact is unsubscribed.
  * @property string $created_at Time at which the contact was created.
+ * @property null|array<string, array{value: mixed, type: string}> $properties Custom properties for the contact. Only available for global contacts.
  */
 class Contact extends Resource
 {

--- a/tests/Fixtures/Contact.php
+++ b/tests/Fixtures/Contact.php
@@ -10,6 +10,9 @@ function contact(): array
         'last_name' => 'Wozniak',
         'created_at' => '2023-10-06 23:47:56.678+00',
         'unsubscribed' => false,
+        'properties' => [
+            'tier' => ['value' => 'premium', 'type' => 'string'],
+        ],
     ];
 }
 


### PR DESCRIPTION
`GET /contacts/:id` returns `properties` where each entry is a `{value, type}` object. The `Contact` docblock omitted the field entirely; this adds `@property null|array<string, array{value: mixed, type: string}> $properties` and the object shape to the test fixture. Create/update request params stay flat maps.

Matches resend-node's `get-contact.interface.ts` and resend-rust's `ContactPropertyResponse`.

docs: https://resend.com/docs/api-reference/contacts/get-contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents and tests the `properties` field on `GET /contacts/:id` responses so it matches the API and other SDKs. Previously the field was undocumented; now `Contact` declares `null|array<string, array{value: mixed, type: string}>` and the fixture includes an example. Only available for global contacts.

- No runtime or API changes; create/update params remain flat maps.
- If you treated `properties` as a flat map, update type hints/usages to the nested `{value, type}` shape.

<sup>Written for commit a354191416c722a36ac179f7c011090abe70c102. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-php/pull/138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

